### PR TITLE
Navigate to ChatsView After Successful Login or Signup

### DIFF
--- a/QuickChat/Views/LoginView.swift
+++ b/QuickChat/Views/LoginView.swift
@@ -69,6 +69,10 @@ struct LoginView: View {
             }
             .padding()
             .navigationBarTitleDisplayMode(.inline)
+            .navigationDestination(
+                isPresented: $isLoggedIn,
+                destination: { ChatsView() }
+            )
         }
     }
 

--- a/QuickChat/Views/SignupView.swift
+++ b/QuickChat/Views/SignupView.swift
@@ -79,6 +79,10 @@ struct SignupView: View {
             }
             .padding()
             .navigationBarTitleDisplayMode(.inline)
+            .navigationDestination(
+                isPresented: $isLoggedIn,
+                destination: { ChatsView() }
+            )
         }
     }
     
@@ -124,6 +128,8 @@ struct SignupView: View {
             // You might want to automatically sign in the user here
             // or send a verification email:
             sendEmailVerification()
+            
+            self.isLoggedIn = true
             
             // Optionally dismiss after delay
             DispatchQueue.main.asyncAfter(deadline: .now() + 2) {


### PR DESCRIPTION
This pull request introduces navigation improvements to the `LoginView` and `SignupView` in the `QuickChat` app, ensuring smoother transitions to the `ChatsView` after login or signup. Additionally, it updates the `SignupView` to set the `isLoggedIn` state upon successful signup.

### Navigation improvements:
* [`QuickChat/Views/LoginView.swift`](diffhunk://#diff-138b4b37a44b52052456dd445f367cc15c6fe111fb11076610483887abd258c5R72-R75): Added a `navigationDestination` modifier to `LoginView` to navigate to `ChatsView` when `isLoggedIn` is `true`.
* [`QuickChat/Views/SignupView.swift`](diffhunk://#diff-f913ad7f9abafee5a90768917b436bbc2b00fc17f99db534bf714c960835f085R82-R85): Added a `navigationDestination` modifier to `SignupView` to navigate to `ChatsView` when `isLoggedIn` is `true`.

### State management:
* [`QuickChat/Views/SignupView.swift`](diffhunk://#diff-f913ad7f9abafee5a90768917b436bbc2b00fc17f99db534bf714c960835f085R132-R133): Updated the signup process to set `isLoggedIn` to `true` after sending a verification email, enabling immediate navigation to `ChatsView`.